### PR TITLE
Change parser return type to protobuf message

### DIFF
--- a/include/citescoop/parser.h
+++ b/include/citescoop/parser.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include "citescoop/citescoop_export.h"
-#include "citescoop/proto/extracted_citation.pb.h"
+#include "citescoop/proto/revision_citations.pb.h"
 
 namespace wikiopencite::citescoop {
 
@@ -101,8 +101,7 @@ class CITESCOOP_EXPORT Parser {
   /// @return Citation protobuf representations.
   ///
   /// @sa Parser(std::function<bool(const std::string&)> filter)
-  std::vector<wikiopencite::proto::ExtractedCitation> parse(
-      const std::string& text);
+  wikiopencite::proto::RevisionCitations parse(const std::string& text);
 
   /// @brief Get configured parser options.
   /// @return Configured parser options.

--- a/src/parser/parser.cc
+++ b/src/parser/parser.cc
@@ -25,9 +25,7 @@ Parser::Parser(std::function<bool(const std::string&)> filter,
 
 Parser::~Parser() = default;
 
-std::vector<wikiopencite::proto::ExtractedCitation> Parser::parse(
-    const std::string& text) {
-
+wikiopencite::proto::RevisionCitations Parser::parse(const std::string& text) {
   return this->impl_->parse(text);
 }
 

--- a/src/parser/parser_impl.cc
+++ b/src/parser/parser_impl.cc
@@ -10,6 +10,7 @@
 #include "boost/parser/parser.hpp"
 
 #include "citescoop/proto/extracted_citation.pb.h"
+#include "citescoop/proto/revision_citations.pb.h"
 #include "citescoop/proto/url.pb.h"
 
 namespace algo = boost::algorithm;
@@ -56,9 +57,8 @@ Parser::ParserImpl::ParserImpl(std::function<bool(const std::string&)> filter,
     // NOLINTNEXTLINE(whitespace/indent_namespace)
     : filter_(filter), options_(options) {}
 
-std::vector<proto::ExtractedCitation> Parser::ParserImpl::parse(
-    const std::string& text) {
-  std::vector<proto::ExtractedCitation> citations = {};
+proto::RevisionCitations Parser::ParserImpl::parse(const std::string& text) {
+  auto citations = proto::RevisionCitations();
 
   auto first = text.begin();
   auto last = text.end();
@@ -71,7 +71,8 @@ std::vector<proto::ExtractedCitation> Parser::ParserImpl::parse(
       algo::to_lower(normalised_name);
 
       if (this->filter_(normalised_name)) {
-        citations.push_back(this->buildCitation(result));
+        auto citation = citations.add_citations();
+        this->buildCitation(result, citation);
       }
     }
 
@@ -81,30 +82,27 @@ std::vector<proto::ExtractedCitation> Parser::ParserImpl::parse(
   return citations;
 }
 
-proto::ExtractedCitation Parser::ParserImpl::buildCitation(
-    const TemplateEntry& entry) {
-
-  auto citation = proto::ExtractedCitation();
-
+void Parser::ParserImpl::buildCitation(const TemplateEntry& entry,
+                                       proto::ExtractedCitation* citation) {
   for (const auto& param : entry.params) {
     auto key = algo::trim_copy(param.key);
     algo::to_lower(key);
 
     if (param.value.has_value()) {
       if (key == "title") {
-        citation.set_title(algo::trim_copy(param.value.value()));
+        citation->set_title(algo::trim_copy(param.value.value()));
       }
       // Identifiers
       // NOLINTNEXTLINE(whitespace/newline, readability/braces)
       else if (key == "doi") {
-        citation.mutable_identifiers()->set_doi(
+        citation->mutable_identifiers()->set_doi(
             this->parseDoi(algo::trim_copy(param.value.value())));
       } else if (key == "isbn") {
-        citation.mutable_identifiers()->set_isbn(
+        citation->mutable_identifiers()->set_isbn(
             algo::trim_copy(param.value.value()));
       } else if (key == "pmid") {
         try {
-          citation.mutable_identifiers()->set_pmid(
+          citation->mutable_identifiers()->set_pmid(
               this->strToIntIdent(algo::trim_copy(param.value.value())));
         } catch (const TemplateParseException& e) {
           if (!this->getOptions().ignore_invalid_ident)
@@ -112,31 +110,29 @@ proto::ExtractedCitation Parser::ParserImpl::buildCitation(
         }
       } else if (key == "pmc") {
         try {
-          citation.mutable_identifiers()->set_pmcid(
+          citation->mutable_identifiers()->set_pmcid(
               this->parsePmcid(algo::trim_copy(param.value.value())));
         } catch (const TemplateParseException& e) {
           if (!this->getOptions().ignore_invalid_ident)
             throw e;
         }
       } else if (key == "issn") {
-        citation.mutable_identifiers()->set_issn(
+        citation->mutable_identifiers()->set_issn(
             algo::trim_copy(param.value.value()));
       }
       // URLs
       // NOLINTNEXTLINE(whitespace/newline, readability/braces)
       else if (key == "url") {
-        auto url_message = citation.add_urls();
+        auto url_message = citation->add_urls();
         url_message->set_type(proto::UrlType::URL_TYPE_DEFAULT);
         url_message->set_url(algo::trim_copy(param.value.value()));
       } else if (key == "archive-url") {
-        auto url_message = citation.add_urls();
+        auto url_message = citation->add_urls();
         url_message->set_type(proto::UrlType::URL_TYPE_ARCHIVE);
         url_message->set_url(algo::trim_copy(param.value.value()));
       }
     }
   }
-
-  return citation;
 }
 
 std::string Parser::ParserImpl::parseDoi(std::string doi) {

--- a/src/parser/parser_impl.h
+++ b/src/parser/parser_impl.h
@@ -12,6 +12,7 @@
 
 #include "citescoop/parser.h"
 #include "citescoop/proto/extracted_citation.pb.h"
+#include "citescoop/proto/revision_citations.pb.h"
 
 namespace wikiopencite::citescoop {
 
@@ -36,8 +37,7 @@ class Parser::ParserImpl {
   /// @param text WikiText input.
   ///
   /// @return List of the extracted citations.
-  std::vector<wikiopencite::proto::ExtractedCitation> parse(
-      const std::string& text);
+  wikiopencite::proto::RevisionCitations parse(const std::string& text);
 
   /// @brief Get configured parser options.
   ///
@@ -45,17 +45,16 @@ class Parser::ParserImpl {
   ParserOptions getOptions() { return this->options_; }
 
  private:
-  /// @brief Build a new @link wikiopencite::proto::ExtractedCitation
+  /// @brief Fill in an existing @link wikiopencite::proto::ExtractedCitation
   /// from the parse result.
   ///
   /// Will iterate through the parameters of the template, extracting
   /// any that are relevant to us to construct the citation.
   ///
   /// @param entry Parser result.
-  ///
-  /// @return Citation including relevant parameter values.
-  wikiopencite::proto::ExtractedCitation buildCitation(
-      const TemplateEntry& entry);
+  /// @param citation Citation to complete.
+  void buildCitation(const TemplateEntry& entry,
+                     proto::ExtractedCitation* citation);
 
   /// @brief Parse a DOI into it's short form.
   ///

--- a/test/src/parser_test.cc
+++ b/test/src/parser_test.cc
@@ -18,13 +18,13 @@ TEST_CASE("Single citation with title", "[parser]") {
 
   auto result = parser.parse("{{cite journal | title=Parsing in Practice}}");
 
-  REQUIRE(result.size() == 1);
-  auto citation = result.at(0);
+  REQUIRE(result.citations_size() == 1);
+  auto citation = result.citations().at(0);
 
   REQUIRE(citation.has_title());
   REQUIRE(citation.title() == "Parsing in Practice");
   REQUIRE(!citation.has_identifiers());
-  REQUIRE(result.at(0).urls_size() == 0);
+  REQUIRE(citation.urls_size() == 0);
 }
 
 /// Ensure that DOI formats are always in the short form (i.e. missing
@@ -33,12 +33,12 @@ TEST_CASE("Consistent DOI formats", "[parser]") {
   auto parser = wikiopencite::citescoop::Parser();
 
   auto result1 = parser.parse("{{cite journal | doi=10.1007/b62130}}");
-  auto citation1 = result1.at(0);
+  auto citation1 = result1.citations().at(0);
   REQUIRE(citation1.identifiers().doi() == "10.1007/b62130");
 
   auto result2 =
       parser.parse("{{cite journal | doi=https://doi.org/10.1007/b62130}}");
-  auto citation2 = result2.at(0);
+  auto citation2 = result2.citations().at(0);
   REQUIRE(citation2.identifiers().doi() == "10.1007/b62130");
 }
 
@@ -51,7 +51,7 @@ TEST_CASE("Extract identifiers", "[parser]") {
       "{{cite journal | doi=10.1007/b62130 | isbn=0-786918-50-0 | "
       "pmid=17322060 | pmc=345678 | issn=2049-3630}}");
 
-  auto citation = result.at(0);
+  auto citation = result.citations().at(0);
   REQUIRE(citation.has_identifiers());
   auto identifiers = citation.identifiers();
 
@@ -71,9 +71,9 @@ TEST_CASE("Extract URLs", "[parser]") {
       "{{cite journal | url=https://abc.com | "
       "archive-url=https://archive.com}}");
 
-  REQUIRE(result.at(0).urls_size() == 2);
+  REQUIRE(result.citations().at(0).urls_size() == 2);
 
-  auto urls = result.at(0).urls();
+  auto urls = result.citations().at(0).urls();
   REQUIRE(urls.at(0).type() == proto::UrlType::URL_TYPE_DEFAULT);
   REQUIRE(urls.at(0).url() == "https://abc.com");
   REQUIRE(urls.at(1).type() == proto::UrlType::URL_TYPE_ARCHIVE);
@@ -86,7 +86,7 @@ TEST_CASE("PMC ID containing PMC prefix") {
   auto parser = wikiopencite::citescoop::Parser();
 
   auto result = parser.parse("{{cite journal|pmc = PMC345678}}");
-  auto citation = result.at(0);
+  auto citation = result.citations().at(0);
 
   REQUIRE(citation.identifiers().pmcid() == 345678);
 }
@@ -112,7 +112,7 @@ TEST_CASE("Numeric identifiers that cannot be cast", "[parser]") {
 
     auto result =
         parser_no_throw.parse("{{cite journal|pmc = abc123|pmid=abc123}}");
-    auto citation = result.at(0);
+    auto citation = result.citations().at(0);
 
     REQUIRE_FALSE(citation.identifiers().has_pmid());
     REQUIRE_FALSE(citation.identifiers().has_pmcid());
@@ -126,7 +126,7 @@ TEST_CASE("Additional whitespace", "[parser]") {
 
   auto result = parser.parse(
       "{{    cite    journal   |   title = Parsing in Practice }}");
-  auto citation = result.at(0);
+  auto citation = result.citations().at(0);
 
   REQUIRE(citation.has_title());
   REQUIRE(citation.title() == "Parsing in Practice");
@@ -138,7 +138,7 @@ TEST_CASE("Minimum whitespace", "[parser]") {
   auto parser = wikiopencite::citescoop::Parser();
 
   auto result = parser.parse("{{cite journal|title = Parsing in Practice}}");
-  auto citation = result.at(0);
+  auto citation = result.citations().at(0);
 
   REQUIRE(citation.has_title());
   REQUIRE(citation.title() == "Parsing in Practice");
@@ -174,7 +174,7 @@ TEST_CASE("Multiple citations in text block", "[parser]") {
       "Evolution |volume=2 |issue=8 |pages=1245–1247 |year=2018 "
       "|doi=10.1038/s41559-018-0602-5}}</ref>");
 
-  REQUIRE(result.size() == 3);
+  REQUIRE(result.citations_size() == 3);
 }
 
 /// Check that we can correctly set and retrieve parser options.

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/WikiOpenCite/registry",
-      "baseline": "845039ea85cfb889bd0d5aa101cf74628532fc7e",
+      "baseline": "0d1e9d5c4848cf706e00bc47fc1aa72a37a64fbc",
       "packages": [
         "citescoop-proto"
       ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -12,7 +12,7 @@
     },
     {
       "name": "citescoop-proto",
-      "version>=": "0.1.4"
+      "version>=": "0.2.0"
     }
   ],
   "default-features": [],


### PR DESCRIPTION
It doesn't make much sense to keep using a std::vector as our return type for parse when we have a perfectly adequate protobuf message (that will actually help us when we are trying to process & store later)

- [x] Breaking Change?